### PR TITLE
General WebExt improvements

### DIFF
--- a/background.js
+++ b/background.js
@@ -83,7 +83,7 @@ chrome.contextMenus.onClicked.addListener(function(info, tab) {
     setOpenIn(openInEnum.CURRENT_TAB);
   } else if (id.startsWith('resurrect-new-tab-')) {
     setOpenIn(openInEnum.NEW_TAB);
-  } else if (id.startsWith('resurrect-new-bg-tab-')) {
+  } else if (id.startsWith('resurrect-bg-tab-')) {
     setOpenIn(openInEnum.NEW_BGTAB);
   } else if (id.startsWith('resurrect-new-window-')) {
     setOpenIn(openInEnum.NEW_WINDOW);

--- a/background.js
+++ b/background.js
@@ -49,13 +49,13 @@ chrome.storage.local.get('openIn', item => {
     }, onCreated);
 
     addConfigItem(
-        context, 'CurrentTab', 'current-tab', openIn == openInEnum.CURRENT_TAB);
+        context, 'CurrentTab', 'current-tab', openIn === openInEnum.CURRENT_TAB);
     addConfigItem(
-        context, 'NewTab', 'new-tab', openIn == openInEnum.NEW_TAB);
+        context, 'NewTab', 'new-tab', openIn === openInEnum.NEW_TAB);
     addConfigItem(
-        context, 'BgTab', 'bg-tab', openIn == openInEnum.BG_TAB);
+        context, 'BgTab', 'bg-tab', openIn === openInEnum.BG_TAB);
     addConfigItem(
-        context, 'NewWindow', 'new-window', openIn == openInEnum.NEW_WINDOW);
+        context, 'NewWindow', 'new-window', openIn === openInEnum.NEW_WINDOW);
   });
 });
 

--- a/common.js
+++ b/common.js
@@ -54,16 +54,16 @@ function updateContextRadios() {
   ['page', 'link'].forEach(context => {
     chrome.contextMenus.update(
         'resurrect-current-tab-' + context,
-        {checked: openIn == openInEnum.CURRENT_TAB});
+        {checked: openIn === openInEnum.CURRENT_TAB});
     chrome.contextMenus.update(
         'resurrect-new-tab-' + context,
-        {checked: openIn == openInEnum.NEW_TAB});
+        {checked: openIn === openInEnum.NEW_TAB});
     chrome.contextMenus.update(
         'resurrect-bg-tab-' + context,
-        {checked: openIn == openInEnum.NEW_BGTAB});
+        {checked: openIn === openInEnum.NEW_BGTAB});
     chrome.contextMenus.update(
         'resurrect-new-window-' + context,
-        {checked: openIn == openInEnum.NEW_WINDOW});
+        {checked: openIn === openInEnum.NEW_WINDOW});
   });
 }
 

--- a/common.js
+++ b/common.js
@@ -59,7 +59,7 @@ function updateContextRadios() {
         'resurrect-new-tab-' + context,
         {checked: openIn == openInEnum.NEW_TAB});
     chrome.contextMenus.update(
-        'resurrect-new-bg-tab-' + context,
+        'resurrect-bg-tab-' + context,
         {checked: openIn == openInEnum.NEW_BGTAB});
     chrome.contextMenus.update(
         'resurrect-new-window-' + context,

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
   "applications": {
     "gecko": {
       "id": "{0c8fbd76-bdeb-4c52-9b24-d587ce7b9dc3}",
-      "strict_min_version": "57.0"
+      "strict_min_version": "57.0a1"
     }
   },
 

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
   "applications": {
     "gecko": {
       "id": "{0c8fbd76-bdeb-4c52-9b24-d587ce7b9dc3}",
-      "strict_min_version": "57.0a1"
+      "strict_min_version": "57.0"
     }
   },
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,11 @@
 {
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
+  "short_name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
   "version": "4",
   "default_locale": "en",
+  "homepage_url": "https://github.com/arantius/resurrect-pages",
 
   "applications": {
     "gecko": {

--- a/popup.js
+++ b/popup.js
@@ -1,6 +1,6 @@
 chrome.storage.local.get('openIn', res => {
   document.querySelectorAll('input[type=radio]').forEach(el => {
-    el.checked = el.value == res.openIn;
+    el.checked = el.value === res.openIn;
   });
 });
 


### PR DESCRIPTION
 - ~~Set minimum version to current FF pre-v57 Nightly~~ (see [discussion comment](https://github.com/arantius/resurrect-pages/pull/28/files/5ab870b7a55a0635558e2491f448d7e5f94526b9#diff-4b1eb3dc48c4e16d49db5b42298fe654))
 - Fixed bug where background tab option in context menu was never selected
 - Compare with triple equals (yes, it is only ever set to a number, but a good practice)
 - Add `shortname` to manifest (needed for Chrome/Opera extensions if you plan to do that too)
 - Added homepage URL to manifest
I would recommend adding the `developer` and `author` keys to the manifest as well.