### PR TITLE
Set minimum FF version to 48

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
   "applications": {
     "gecko": {
       "id": "{0c8fbd76-bdeb-4c52-9b24-d587ce7b9dc3}",
-      "strict_min_version": "57.0"
+      "strict_min_version": "48.0"
     }
   },
 


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Browser_support_for_JavaScript_APIs , the APIs used in this extension started being available on FF v48.

List of API endpoints I found being used:
- contextMenus.create
- contextMenus.onClicked
- contextMenus.update
- i18n.getMessage
- runtime.lastError
- storage.local
- tabs.create
- tabs.query
- tabs.update
- windows.create