### PR TITLE
Specify openerTabId for opened tabs

### DIFF
--- a/background.js
+++ b/background.js
@@ -76,19 +76,19 @@ chrome.contextMenus.onClicked.addListener(function(info, tab) {
   }
 
   if (id.startsWith('resurrect-google-')) {
-    goToUrl(genGoogleUrl(url), openIn);
+    goToUrl(genGoogleUrl(url), openIn, tab.id);
   } else if (id.startsWith('resurrect-googletext-')) {
-    goToUrl(genGoogleTextUrl(url), openIn);
+    goToUrl(genGoogleTextUrl(url), openIn, tab.id);
   } else if (id.startsWith('resurrect-archive-')) {
-    goToUrl(genIaUrl(url), openIn);
+    goToUrl(genIaUrl(url), openIn, tab.id);
   } else if (id.startsWith('resurrect-archivelist-')) {
-    goToUrl(genIaListUrl(url), openIn);
+    goToUrl(genIaListUrl(url), openIn, tab.id);
   } else if (id.startsWith('resurrect-archiveis-')) {
-    goToUrl(genArchiveIsUrl(url), openIn);
+    goToUrl(genArchiveIsUrl(url), openIn, tab.id);
   } else if (id.startsWith('resurrect-webcitation-')) {
-    goToUrl(genWebCiteUrl(url), openIn);
+    goToUrl(genWebCiteUrl(url), openIn, tab.id);
   } else if (id.startsWith('resurrect-mementoweb-')) {
-    goToUrl(genMementoUrl(url), openIn);
+    goToUrl(genMementoUrl(url), openIn, tab.id);
   } else if (id.startsWith('resurrect-current-tab-')) {
     setOpenIn(openInEnum.CURRENT_TAB);
   } else if (id.startsWith('resurrect-new-tab-')) {

--- a/common.js
+++ b/common.js
@@ -79,16 +79,16 @@ function updateContextRadios() {
 }
 
 
-function goToUrl(url, where) {
+function goToUrl(url, where, openerTabId) {
   switch(Number(where)) {
     case openInEnum.CURRENT_TAB:
       chrome.tabs.update({'url': url});
       break;
     case openInEnum.NEW_TAB:
-      chrome.tabs.create({'url': url});
+      chrome.tabs.create({'url': url, openerTabId});
       break;
     case openInEnum.NEW_BGTAB:
-      chrome.tabs.create({'url': url, 'active': false});
+      chrome.tabs.create({'url': url, 'active': false, openerTabId});
       break;
     case openInEnum.NEW_WINDOW:
       chrome.windows.create({'url': url});

--- a/popup.js
+++ b/popup.js
@@ -19,7 +19,7 @@ function resurrect(gen) {
       logLastError();
       let url = gen(tabObj[0].url);
       console.info('Resurrecting via URL', url);
-      goToUrl(url, openIn);
+      goToUrl(url, openIn, tabObj[0].id);
       window.close();
     });
   }


### PR DESCRIPTION
The method `tabs.create()` accepts a parameter `openerTabId` to specify the opener tab. When it is specified Firefox backs the focus of tabs to the opener when the new tab is closed, so this change improves user experience around tab operations. (Moreover, some addons like https://addons.mozilla.org/firefox/addon/tree-style-tab/ may use the information to detect relation of tabs.)

How about this change?