### PR TITLE
properly handle edge cases on page/tab URLs

### DIFF
--- a/background.js
+++ b/background.js
@@ -75,10 +75,6 @@ chrome.contextMenus.onClicked.addListener(function(info, tab) {
     url = info.linkUrl;
   }
 
-  if (url.startsWith('about:reader?url=')) {
-    url = decodeURIComponent(url.replace('about:reader?url=', ''));
-  }
-
   if (id.startsWith('resurrect-google-')) {
     goToUrl(genGoogleUrl(url), openIn, tab.id);
   } else if (id.startsWith('resurrect-googletext-')) {

--- a/background.js
+++ b/background.js
@@ -74,6 +74,9 @@ chrome.contextMenus.onClicked.addListener(function(info, tab) {
   } else if (id.endsWith('-link')) {
     url = info.linkUrl;
   }
+  
+  if (url.startsWith("about:reader?url=")
+      url = decodeURIcomponent(url.replace("about:reader?url=", ""))
 
   if (id.startsWith('resurrect-google-')) {
     goToUrl(genGoogleUrl(url), openIn, tab.id);

--- a/background.js
+++ b/background.js
@@ -74,9 +74,10 @@ chrome.contextMenus.onClicked.addListener(function(info, tab) {
   } else if (id.endsWith('-link')) {
     url = info.linkUrl;
   }
-  
-  if (url.startsWith("about:reader?url=")
-      url = decodeURIcomponent(url.replace("about:reader?url=", ""))
+
+  if (url.startsWith('about:reader?url=')) {
+    url = decodeURIComponent(url.replace('about:reader?url=', ''))
+  }
 
   if (id.startsWith('resurrect-google-')) {
     goToUrl(genGoogleUrl(url), openIn, tab.id);

--- a/background.js
+++ b/background.js
@@ -76,7 +76,7 @@ chrome.contextMenus.onClicked.addListener(function(info, tab) {
   }
 
   if (url.startsWith('about:reader?url=')) {
-    url = decodeURIComponent(url.replace('about:reader?url=', ''))
+    url = decodeURIComponent(url.replace('about:reader?url=', ''));
   }
 
   if (id.startsWith('resurrect-google-')) {

--- a/background.js
+++ b/background.js
@@ -70,32 +70,36 @@ chrome.contextMenus.onClicked.addListener(function(info, tab) {
   let id = info.menuItemId;
   let url = null;
   if (id.endsWith('-page')) {
-    url = info.pageUrl;
+    url = processPageUrlEdgeCases(info.pageUrl);
   } else if (id.endsWith('-link')) {
     url = info.linkUrl;
   }
 
-  if (id.startsWith('resurrect-google-')) {
-    goToUrl(genGoogleUrl(url), openIn, tab.id);
-  } else if (id.startsWith('resurrect-googletext-')) {
-    goToUrl(genGoogleTextUrl(url), openIn, tab.id);
-  } else if (id.startsWith('resurrect-archive-')) {
-    goToUrl(genIaUrl(url), openIn, tab.id);
-  } else if (id.startsWith('resurrect-archivelist-')) {
-    goToUrl(genIaListUrl(url), openIn, tab.id);
-  } else if (id.startsWith('resurrect-archiveis-')) {
-    goToUrl(genArchiveIsUrl(url), openIn, tab.id);
-  } else if (id.startsWith('resurrect-webcitation-')) {
-    goToUrl(genWebCiteUrl(url), openIn, tab.id);
-  } else if (id.startsWith('resurrect-mementoweb-')) {
-    goToUrl(genMementoUrl(url), openIn, tab.id);
-  } else if (id.startsWith('resurrect-current-tab-')) {
+  if (url != null) {
+    if (id.startsWith('resurrect-google-')) {
+      goToUrl(genGoogleUrl(url), openIn, tab.id);
+    } else if (id.startsWith('resurrect-googletext-')) {
+      goToUrl(genGoogleTextUrl(url), openIn, tab.id);
+    } else if (id.startsWith('resurrect-archive-')) {
+      goToUrl(genIaUrl(url), openIn, tab.id);
+    } else if (id.startsWith('resurrect-archivelist-')) {
+      goToUrl(genIaListUrl(url), openIn, tab.id);
+    } else if (id.startsWith('resurrect-archiveis-')) {
+      goToUrl(genArchiveIsUrl(url), openIn, tab.id);
+    } else if (id.startsWith('resurrect-webcitation-')) {
+      goToUrl(genWebCiteUrl(url), openIn, tab.id);
+    } else if (id.startsWith('resurrect-mementoweb-')) {
+      goToUrl(genMementoUrl(url), openIn, tab.id);
+    }
+  }
+
+  if (id.startsWith('resurrect-current-tab-')) {
     setOpenIn(openInEnum.CURRENT_TAB);
   } else if (id.startsWith('resurrect-new-tab-')) {
-    setOpenIn(openInEnum.NEW_TAB);
+      setOpenIn(openInEnum.NEW_TAB);
   } else if (id.startsWith('resurrect-bg-tab-')) {
-    setOpenIn(openInEnum.NEW_BGTAB);
+      setOpenIn(openInEnum.NEW_BGTAB);
   } else if (id.startsWith('resurrect-new-window-')) {
-    setOpenIn(openInEnum.NEW_WINDOW);
+      setOpenIn(openInEnum.NEW_WINDOW);
   }
 });

--- a/common.js
+++ b/common.js
@@ -58,12 +58,15 @@ function genMementoUrl(url) {
  * file:// scheme pages and FF reader mode
  */
 function processPageUrlEdgeCases(url) {
-  if (url.startsWith('about:reader?url='))
-    return decodeURIComponent(url.replace('about:reader?url=', ''));
-  else if (!url.startsWith('file://'))
+  if (!url.startsWith('file://')) {
+    if (url.startsWith('about:reader?url=')) {
+      return decodeURIComponent(url.replace('about:reader?url=', ''));
+    }
     return url;
-  else
+  }
+  else {
     return null;
+  }
 }
 
 

--- a/common.js
+++ b/common.js
@@ -58,15 +58,13 @@ function genMementoUrl(url) {
  * file:// scheme pages and FF reader mode
  */
 function processPageUrlEdgeCases(url) {
-  if (!url.startsWith('file://')) {
-    if (url.startsWith('about:reader?url=')) {
-      return decodeURIComponent(url.replace('about:reader?url=', ''));
-    }
-    return url;
+  if (url.startsWith('about:reader?url=')) {
+    return decodeURIComponent(url.replace('about:reader?url=', ''));
   }
-  else {
-    return null;
+  else if (url.startsWith('file:') || url.startsWith('about:')) {
+    return null
   }
+  return url;
 }
 
 

--- a/common.js
+++ b/common.js
@@ -54,6 +54,19 @@ function genMementoUrl(url) {
 }
 
 
+/* process edge cases in the page URL
+ * file:// scheme pages and FF reader mode
+ */
+function processPageUrlEdgeCases(url) {
+  if (url.startsWith("about:reader?url="))
+    return decodeURIComponent(url.replace("about:reader?url=", ""));
+  else if (!url.startsWith("file://"))
+    return url;
+  else
+    return null;
+}
+
+
 function setOpenIn(where) {
   openIn = where;
   chrome.storage.local.set({openIn: openIn}, logLastError);

--- a/common.js
+++ b/common.js
@@ -58,9 +58,9 @@ function genMementoUrl(url) {
  * file:// scheme pages and FF reader mode
  */
 function processPageUrlEdgeCases(url) {
-  if (url.startsWith("about:reader?url="))
-    return decodeURIComponent(url.replace("about:reader?url=", ""));
-  else if (!url.startsWith("file://"))
+  if (url.startsWith('about:reader?url='))
+    return decodeURIComponent(url.replace('about:reader?url=', ''));
+  else if (!url.startsWith('file://'))
     return url;
   else
     return null;

--- a/popup.js
+++ b/popup.js
@@ -18,6 +18,11 @@ function resurrect(gen) {
     chrome.tabs.query({active: true, currentWindow: true}, tabObj => {
       logLastError();
       let url = gen(tabObj[0].url);
+
+      if (url.startsWith('about:reader?url=')) {
+        url = decodeURIComponent(url.replace('about:reader?url=', ''));
+      }
+
       console.info('Resurrecting via URL', url);
       goToUrl(url, openIn, tabObj[0].id);
       window.close();

--- a/popup.js
+++ b/popup.js
@@ -17,11 +17,12 @@ function resurrect(gen) {
   return function() {
     chrome.tabs.query({active: true, currentWindow: true}, tabObj => {
       logLastError();
-      let url = gen(tabObj[0].url);
-
-      if (url.startsWith('about:reader?url=')) {
-        url = decodeURIComponent(url.replace('about:reader?url=', ''));
+      
+      var og_url = tabObj[0].url;
+      if (og_url.startsWith('about:reader?url=')) {
+        og_url = decodeURIComponent(og_url.replace('about:reader?url=', ''));
       }
+      let url = gen(og_url);
 
       console.info('Resurrecting via URL', url);
       goToUrl(url, openIn, tabObj[0].id);

--- a/popup.js
+++ b/popup.js
@@ -17,15 +17,16 @@ function resurrect(gen) {
   return function() {
     chrome.tabs.query({active: true, currentWindow: true}, tabObj => {
       logLastError();
-      
-      var og_url = tabObj[0].url;
-      if (og_url.startsWith('about:reader?url=')) {
-        og_url = decodeURIComponent(og_url.replace('about:reader?url=', ''));
-      }
-      let url = gen(og_url);
 
-      console.info('Resurrecting via URL', url);
-      goToUrl(url, openIn, tabObj[0].id);
+      var url = processPageUrlEdgeCases(tabObj[0].url);
+
+      if (url != null)
+      {
+        let archiveUrl = gen(url);
+        console.info('Resurrecting via URL', archiveUrl);
+        goToUrl(archiveUrl, openIn, tabObj[0].id);
+      }
+
       window.close();
     });
   }


### PR DESCRIPTION
Thanks for the work on this extension. 

This PR adds a check to properly handle the case where the current page view is a reader mode (in Firefox), sending the actual raw URL to resurrect pages.

Enter `about:reader?url=https%3A%2F%2Fwww.howtogeek.com%2F352267%2Fhow-to-use-the-reader-view-in-firefox%2F` in browser and the resurrect pages from the toolbar links.